### PR TITLE
Allow getting stop by string id

### DIFF
--- a/lib/mta.js
+++ b/lib/mta.js
@@ -47,7 +47,7 @@ Mta.prototype.stop = function (stopId) {
         return reject(err);
       }
 
-      if (_.isNumber(stopId)) {
+      if (_.isNumber(stopId) || _.isString(stopId)) {
         data = data[stopId];
       } else if (_.isArray(stopId)) {
         data = _.pick(data, stopId);

--- a/test/mta.js
+++ b/test/mta.js
@@ -33,6 +33,14 @@ describe('MTA', function () {
     });
   });
 
+  it('should get info for S30S', function() {
+    return mta.stop('S30S')
+    .then(function (result) {
+      result.stop_id.should.equal('S30S');
+      result.should.have.property('stop_name');
+    });
+  });
+
   it('should get info for multiple MTA subway stop', function () {
     return mta.stop(stopIds)
     .then(function (result) {


### PR DESCRIPTION
When calling `mta.stop(stopId)`, a check is made to see if `stopId` is a number, an array, or is empty. `data` is an object, and its keys are strings, furthermore, some stops have non-numeric ids (like S30S), which are inaccessible via this method.

This change allows getting stops by id when their ids are non-numeric.
